### PR TITLE
Safer key vault name

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -42,7 +42,7 @@ module keyVault './core/security/keyvault.bicep' = {
   name: 'keyvault'
   scope: resourceGroup
   params: {
-    name: '${take(prefix, 17)}-vault'
+    name: '${take(replace(prefix, '-', ''), 17)}-vault'
     location: location
     tags: tags
     principalId: principalId


### PR DESCRIPTION
## Purpose

Remove hyphens from KeyVault name since it freaks out if there are multiple dashes in a row. 

```
VaultNameNotValid: The vault name 'django-azure-aca--vault' is invalid. A vault's name must be between 3-24 alphanumeric characters. The name must begin with a letter, end with a letter or digit, and not contain consecutive hyphens. Follow this link for more information: https://go.microsoft.com/fwlink/?linkid=2147742
```

Another approach is to replace '--' with '-' after creating the name, but this is simpler.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No (unless you have an existing deploy!)
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

`azd up`
